### PR TITLE
Fix rendering steps when going back & add padding to flow-ui-step container.

### DIFF
--- a/src/js/flow/step.js
+++ b/src/js/flow/step.js
@@ -31,8 +31,10 @@ export class FlowStep extends EventTargetMixin(EventTarget) {
    *
    * @param {Flow} flow
    * @param {*} topic
-   * @param {FlowStepOptions} options
-   * @param {*} fn
+   * @param {object} options
+   * @param {boolean} options.backTarget
+   * @param {*} options.topic
+   * @param {Function} fn
    */
   constructor(flow, topic, options, fn) {
     super();

--- a/src/js/flow/ui-step.js
+++ b/src/js/flow/ui-step.js
@@ -32,7 +32,6 @@ customElements.define(
       this.setStepClasses(step, isLast);
 
       try {
-
         return step.render();
       } finally {
         if (isLast) {

--- a/src/js/flow/ui.js
+++ b/src/js/flow/ui.js
@@ -3,6 +3,7 @@ import { LitElement, html, nothing } from "lit";
 import { FlowStepState } from "./index";
 import { Flow } from "./index";
 import { repeat } from "lit/directives/repeat.js";
+import { keyed } from "lit/directives/keyed.js";
 import "./ui-step";
 const htmlElm = document.documentElement;
 
@@ -78,14 +79,16 @@ export class FlowUI extends EventTargetMixin(LitElement) {
 
   renderFlow() {
     return html`
-      ${repeat(this.#flow.steps, (step, index) => {
-        return html`<flow-ui-step
+      ${keyed(this.#flow.steps, html`
+        ${repeat(this.#flow.steps, (step, index) => {
+          return html`<flow-ui-step
           .step="${step}"
           .isActive=${step === this.#flow.currentStep}
           .index="${index}"
         >
         </flow-ui-step>`;
-      })}
+        })}
+      `)}
     `;
   }
 

--- a/src/scss/_flow-full-page.scss
+++ b/src/scss/_flow-full-page.scss
@@ -19,7 +19,7 @@
             align-items: center;
             justify-content: center;
             justify-items: center;
-            justify-items: center;
+            padding: 15px 10px;
 
             scroll-snap-align: center;
 


### PR DESCRIPTION
Aligned the contents of the container by adding padding for better spacing. The redundant 'justify-items: center;' was also removed to clean up the code.

Fixing issue with steps not rendering at some points by using `keyed` from Lit. This ensures the rendering is done in completion and can't be shortcutted by the Lit engine to 'smart render'.